### PR TITLE
Add Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,18 +18,24 @@ var packageJson = require("./package.json");
 var arch = process.arch;
 var operatingSystem = process.platform;
 var filename = operatingSystem + "-" + arch + ".tar.gz";
-var elmBins = [
-  "make",
-  "repl",
-  "package",
-  "reactor"
-]
 var versionPattern = /([0-9]\D.[0-9].?([0-9]?))|(master)/g
 
 if (process.platform === 'win32') {
     var usrBin = os.homedir() + "/Appdata/Local/Elm Version Manager";
+    var elmBins = [
+      "make.exe",
+      "repl.exe",
+      "package.exe",
+      "reactor.exe"
+    ];
 } else {
     var usrBin = "/usr/local/bin";
+    var elmBins = [
+      "make",
+      "repl",
+      "package",
+      "reactor"
+    ];
 }
 
 
@@ -98,7 +104,7 @@ var use = function(version) {
         }
 
         if (process.platform === 'win32') {
-          fs.copySync(EVM_DIR + "/" + version + "/" + "elm-" + bin + '.exe', usrBin + "/elm-" + bin + '.exe');
+          fs.copySync(EVM_DIR + "/" + version + "/" + "elm-" + bin, usrBin + "/elm-" + bin);
         } else {
           fs.symlinkSync(EVM_DIR + "/" + version + "/" + "elm-" + bin, usrBin + '/elm-' + bin);
         }

--- a/index.js
+++ b/index.js
@@ -23,18 +23,20 @@ var versionPattern = /([0-9]\D.[0-9].?([0-9]?))|(master)/g
 if (process.platform === 'win32') {
     var usrBin = os.homedir() + "/Appdata/Local/Elm Version Manager";
     var elmBins = [
-      "make.exe",
-      "repl.exe",
-      "package.exe",
-      "reactor.exe"
+      "elm.exe",
+      "elm-make.exe",
+      "elm-repl.exe",
+      "elm-package.exe",
+      "elm-reactor.exe"
     ];
 } else {
     var usrBin = "/usr/local/bin";
     var elmBins = [
-      "make",
-      "repl",
-      "package",
-      "reactor"
+      "elm",
+      "elm-make",
+      "elm-repl",
+      "elm-package",
+      "elm-reactor"
     ];
 }
 
@@ -97,19 +99,19 @@ var use = function(version) {
     console.log(chalk.yellow("Using: " + version + "\n"));
 
     elmBins.forEach(function(bin) {
-      fs.unlink(usrBin + '/elm-' + bin, function(err) {
+      fs.unlink(usrBin + '/' + bin, function(err) {
         if (err && err.code !== "ENOENT") {
           console.log(chalk.red(err.message));
           return;
         }
 
         if (process.platform === 'win32') {
-          fs.copySync(EVM_DIR + "/" + version + "/" + "elm-" + bin, usrBin + "/elm-" + bin);
+          fs.copySync(EVM_DIR + "/" + version + "/" + bin, usrBin + "/" + bin);
         } else {
-          fs.symlinkSync(EVM_DIR + "/" + version + "/" + "elm-" + bin, usrBin + '/elm-' + bin);
+          fs.symlinkSync(EVM_DIR + "/" + version + "/" + bin, usrBin + '/' + bin);
         }
 
-        console.log(chalk.green("🚀 " + " elm-" + bin + " good to go!"));
+        console.log(chalk.green("🚀 " + bin + " good to go!"));
       });
     });
   } else {
@@ -140,15 +142,15 @@ var install = function(version) {
         console.log(chalk.yellow("\nDownloaded " + version + " 🍻\n"));
 
         elmBins.forEach(function(exec) {
-          fs.stat(desPath + "/" + "elm-" + exec, function(err, stat) {
+          fs.stat(desPath + "/" + exec, function(err, stat) {
             if (err) {
               console.log(chalk.red("Error " + err.message));
               return;
             } else if (!stat.isFile()) {
-              console.log(chalk.red("Error file: " + "elm-" + exec + "is not a file"));
+              console.log(chalk.red("Error file: " + exec + "is not a file"));
               return;
             } else {
-              console.log(chalk.green("☁️ 🚀 ☁️  installed elm-" + exec + " for version: " + version));
+              console.log(chalk.green("☁️ 🚀 ☁️  installed " + exec + " for version: " + version));
             }
           });
         });

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ var use = function(version) {
         } else {
           fs.symlinkSync(EVM_DIR + "/" + version + "/" + "elm-" + bin, usrBin + '/elm-' + bin);
         }
-        
+
         console.log(chalk.green("🚀 " + " elm-" + bin + " good to go!"));
       });
     });
@@ -120,7 +120,7 @@ var install = function(version) {
 
   request.get(url, function(err, response) {
     if (err) {
-      console.log(chalk.red("Error communitcating with URL: " + url + " " + error));
+      console.log(chalk.red("Error communicating with URL: " + url + " " + error));
     }
 
     if (response.statusCode == 404) {
@@ -178,11 +178,11 @@ var listRemote = function() {
   console.log(chalk.yellow("Getting information from server ⛵\n"));
   request.get(URL_BASE, function(err, response) {
     if (err) {
-      console.log(chalk.red("Error communitcating with URL: " + url + " " + error));
+      console.log(chalk.red("Error communicating with URL: " + url + " " + error));
     };
 
     if (response.statusCode == 404) {
-      console.log(chalk.red("Unfortunately, there the package binaries cannot be found"));
+      console.log(chalk.red("Unfortunately, the package binaries cannot be found"));
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ var packageJson = require("./package.json");
 var arch = process.arch;
 var operatingSystem = process.platform;
 var filename = operatingSystem + "-" + arch + ".tar.gz";
-var usrBin = "/usr/local/bin";
 var elmBins = [
   "make",
   "repl",
@@ -26,6 +25,12 @@ var elmBins = [
   "reactor"
 ]
 var versionPattern = /([0-9]\D.[0-9].?([0-9]?))|(master)/g
+
+if (process.platform === 'win32') {
+    var usrBin = os.homedir() + "/Appdata/Local/Elm Version Manager";
+} else {
+    var usrBin = "/usr/local/bin";
+}
 
 
 var hasEvmDir = function() {

--- a/index.js
+++ b/index.js
@@ -96,7 +96,13 @@ var use = function(version) {
           console.log(chalk.red(err.message));
           return;
         }
-        fs.symlinkSync(EVM_DIR + "/" + version + "/" + "elm-" + bin, usrBin + '/elm-' + bin)
+
+        if (process.platform === 'win32') {
+          fs.copySync(EVM_DIR + "/" + version + "/" + "elm-" + bin + '.exe', usrBin + "/elm-" + bin + '.exe');
+        } else {
+          fs.symlinkSync(EVM_DIR + "/" + version + "/" + "elm-" + bin, usrBin + '/elm-' + bin);
+        }
+        
         console.log(chalk.green("🚀 " + " elm-" + bin + " good to go!"));
       });
     });


### PR DESCRIPTION
#1

This contribution adds Windows support. In my limited testing, it all seems to work fine using the npm-installed version of Elm — I can't say whether the dedicated installer from elm-lang.org has any clash with it, what with registry keys and all. 

Windows lacks a direct equivalent to /usr/local/bin. Instead, when you `use 0.18.0`, 0.18.0's executables are copied into the `%USERPROFILE\AppData\Local\Elm Version Manager` folder for the current user. Because Windows doesn't allow non-administrators to create symlinks, that's a direct file copy overwriting what was previously in use.

There's one thing necessary for use that I haven't done: added that folder to the `%PATH%` variable. Users will need to manually add `%USERPROFILE\AppData\Local\Elm Version Manager` to their `%PATH%`  using the Windows control panel (System → Advanced System Settings → Environment Variables) or the command prompt. I left this out because I wasn't sure an NPM package permanently altering your environment variables was something users would appreciate, might be better as a manual step detailed in the README. Could always add a Y/N option for that, though.

Someone, please let me know if there's a better way to implement this, I haven't done anything quite like it before and I'm totally expecting my solution to be naïve. Anyway, I'm on Windows for the moment, I needed an Elm version manager, I found this, I added support, and it's been working for my needs today.